### PR TITLE
feat: add certificate validity test cases from model-transparency#663

### DIFF
--- a/.github/workflows/conformance-ci.yml
+++ b/.github/workflows/conformance-ci.yml
@@ -72,3 +72,4 @@ jobs:
           xfail: |
             test_roundtrip[key-empty-model-rejected
             test_verify[negative/certificate-no-code-signing-eku_fail
+            test_verify[negative/certificate-not-yet-valid_fail

--- a/conformance/TEST_CASES.md
+++ b/conformance/TEST_CASES.md
@@ -1,6 +1,6 @@
 # Conformance test cases
 
-**86 tests** total: **37 roundtrip** (live sign, then verify) and **49 verify** (pre-committed offline bundles). This document indexes the **Open Model Signing (OMS)** conformance suite in this repository. Requirements are as defined in the [OMS Specification](https://github.com/ossf/model-signing-spec/blob/main/spec/v1.0.md); section references below use the same numbering as that spec.
+**90 tests** total: **37 roundtrip** (live sign, then verify) and **53 verify** (pre-committed offline bundles). This document indexes the **Open Model Signing (OMS)** conformance suite in this repository. Requirements are as defined in the [OMS Specification](https://github.com/ossf/model-signing-spec/blob/main/spec/v1.0.md); section references below use the same numbering as that spec.
 
 **oms-schemas:** Every successful roundtrip run validates produced bundles and decoded DSSE payloads against the published OMS JSON Schemas from the `oms-schemas` package (outer bundle, statement, predicate, resources), in addition to the test harness’s own structural checks.
 
@@ -17,7 +17,10 @@
 | §4.1 | sigstore wrong issuer rejection | sigstore-wrong-issuer_fail | Covered (CI-only) |
 | §4.1 | Accept hint or rawBytes in publicKey | historical-v0.3.1/v1.0.0 (rawBytes) vs v1.1.0 (hint) | Covered |
 | §4.1 | Accept keyid absent/empty/null | Go vs Python bundles | Covered |
-| §4.1 | Certificate validity period enforced | certificate-expired_fail | Covered |
+| §4.1 | Certificate validity period enforced | certificate-expired_fail, certificate-not-yet-valid_fail | Covered |
+| §4.1 | Intermediate CA validity period enforced | certificate-expired-intermediate_fail | Covered |
+| §4.1 | Root CA validity period enforced | certificate-expired-root_fail | Covered |
+| §4.1 | Full-chain expiry rejected (no time-pinning) | certificate-all-expired_fail | Covered |
 | §4.1 | Certificate must have code_signing EKU | certificate-no-code-signing-eku_fail | Covered |
 | §4.1 | Method-specific verificationMaterial match | key-verify-as-certificate_fail, certificate-verify-as-key_fail, sigstore-verify-as-key_fail, key-verify-as-sigstore_fail, certificate-verify-as-sigstore_fail | Covered |
 | §4.1 | Producers MUST use hint field in publicKey | _assert_key_uses_hint (all key roundtrip) | Covered |
@@ -365,7 +368,7 @@ Paths are under `test/test-cases/verify/…` unless noted. “Verify” means th
 
 **Impact if it fails:** Latest sigstore bundles from Go v1.1.0 are unverifiable.
 
-### Negative cases (28)
+### Negative cases (32)
 
 #### `key-simple-tampered-content_fail`
 **Spec:** §8.4
@@ -548,6 +551,58 @@ Paths are under `test/test-cases/verify/…` unless noted. “Verify” means th
 **Expected outcome:** Non-zero exit; temporal validation must fail.
 
 **Impact if it fails:** **Security failure** - decommissioned or expired credentials could be accepted as valid.
+
+#### `certificate-not-yet-valid_fail`
+**Spec:** §4.1, §8.2
+
+**What it tests:** A leaf certificate whose **validity period has not yet started** (notBefore is one year in the future) while the chain and signature are otherwise valid.
+
+**Setup:** Generated leaf cert with notBefore = now + 1 year, notAfter = now + 2 years, issued by the standard intermediate CA. Signing or verification uses this future-dated certificate.
+
+**Why it exists:** X.509 temporal validation requires checking both notBefore and notAfter. A certificate that is not yet valid must be rejected just as firmly as one that has expired.
+
+**Expected outcome:** Non-zero exit; temporal validation must fail (certificate not yet valid).
+
+**Impact if it fails:** **Security failure** - certificates issued for future use could be accepted before their intended activation date, bypassing temporal controls.
+
+#### `certificate-expired-intermediate_fail`
+**Spec:** §4.1, §8.2
+
+**What it tests:** A valid leaf certificate whose **intermediate CA** has an expired validity period (notAfter 2020-01-02). The root CA and leaf are otherwise valid.
+
+**Setup:** Dedicated expired intermediate CA cert (notBefore 2020-01-01, notAfter 2020-01-02) signed by the standard root CA. A valid leaf cert is issued from this expired intermediate.
+
+**Why it exists:** X.509 chain validation must verify the validity period of every certificate in the chain, not just the leaf. An expired intermediate CA invalidates all certificates it issued.
+
+**Expected outcome:** Non-zero exit; chain temporal validation must fail at the intermediate CA level.
+
+**Impact if it fails:** **Security failure** - an expired intermediate CA could continue to be accepted, allowing its leaf certificates to verify despite the CA being decommissioned.
+
+#### `certificate-expired-root_fail`
+**Spec:** §4.1, §8.2
+
+**What it tests:** A valid leaf certificate and valid intermediate CA whose **root CA** (trust anchor) has an expired validity period (notAfter 2020-01-02). All other aspects of the chain are correct.
+
+**Setup:** Dedicated expired root CA cert. Valid intermediate and leaf certs issued from this expired root. Verification uses the expired root as trust anchor.
+
+**Why it exists:** Even the trust anchor must be temporally valid. An expired root CA means the entire trust chain is no longer authoritative.
+
+**Expected outcome:** Non-zero exit; chain temporal validation must fail at the root CA level.
+
+**Impact if it fails:** **Security failure** - an expired root CA could continue to anchor trust chains, undermining the entire certificate lifecycle management model.
+
+#### `certificate-all-expired_fail`
+**Spec:** §4.1, §8.2
+
+**What it tests:** An entire certificate chain where **root, intermediate, and leaf** are all expired. This is the scenario identified in sigstore/model-transparency#663 where implementations that pin verification time to the leaf's notBefore could tautologically pass chain validation.
+
+**Setup:** All three certificates have validity periods entirely in the past (root and intermediate: Jan-Jun 2020, leaf: Feb-Mar 2020). The leaf's notBefore falls within the CA validity windows, so a verifier that pins time to notBefore would incorrectly find all certs valid.
+
+**Why it exists:** Verifiers must use the current wall-clock time for validity checks, not the certificate's own notBefore. Pinning to notBefore creates a tautological pass: any self-consistent chain of expired certs would verify, defeating the purpose of certificate expiry.
+
+**Expected outcome:** Non-zero exit; temporal validation must fail for all certificates in the chain.
+
+**Impact if it fails:** **Critical security failure** - the time-pinning bug (issue #663) means any expired certificate chain that was internally consistent would be accepted, completely negating certificate expiry as a security control.
 
 #### `key-verify-as-certificate_fail`
 **Spec:** §4.1
@@ -1295,8 +1350,8 @@ Example (abbreviated):
 | Category | Count |
 |---|---|
 | Verify - positive | 6 |
-| Verify - negative | 28 |
+| Verify - negative | 32 |
 | Verify - historical | 15 |
 | Roundtrip | 37 |
-| **Total** | **86** |
+| **Total** | **90** |
 

--- a/conformance/TEST_CASES.md
+++ b/conformance/TEST_CASES.md
@@ -1,6 +1,6 @@
 # Conformance test cases
 
-**90 tests** total: **37 roundtrip** (live sign, then verify) and **53 verify** (pre-committed offline bundles). This document indexes the **Open Model Signing (OMS)** conformance suite in this repository. Requirements are as defined in the [OMS Specification](https://github.com/ossf/model-signing-spec/blob/main/spec/v1.0.md); section references below use the same numbering as that spec.
+**92 tests** total: **37 roundtrip** (live sign, then verify) and **55 verify** (pre-committed offline bundles). This document indexes the **Open Model Signing (OMS)** conformance suite in this repository. Requirements are as defined in the [OMS Specification](https://github.com/ossf/model-signing-spec/blob/main/spec/v1.0.md); section references below use the same numbering as that spec.
 
 **oms-schemas:** Every successful roundtrip run validates produced bundles and decoded DSSE payloads against the published OMS JSON Schemas from the `oms-schemas` package (outer bundle, statement, predicate, resources), in addition to the test harness’s own structural checks.
 
@@ -19,6 +19,8 @@
 | §4.1 | Accept keyid absent/empty/null | Go vs Python bundles | Covered |
 | §4.1 | Certificate validity period enforced | certificate-expired_fail, certificate-not-yet-valid_fail | Covered |
 | §4.1 | Intermediate CA validity period enforced | certificate-expired-intermediate_fail | Covered |
+| §4.1 | Not-yet-valid intermediate CA rejected | certificate-not-yet-valid-intermediate_fail | Covered |
+| §4.1 | Cascading expiry (intermediate + leaf both expired) | certificate-expired-intermediate-expired-leaf_fail | Covered |
 | §4.1 | Root CA validity period enforced | certificate-expired-root_fail | Covered |
 | §4.1 | Full-chain expiry rejected (no time-pinning) | certificate-all-expired_fail | Covered |
 | §4.1 | Certificate must have code_signing EKU | certificate-no-code-signing-eku_fail | Covered |
@@ -368,7 +370,7 @@ Paths are under `test/test-cases/verify/…` unless noted. “Verify” means th
 
 **Impact if it fails:** Latest sigstore bundles from Go v1.1.0 are unverifiable.
 
-### Negative cases (32)
+### Negative cases (34)
 
 #### `key-simple-tampered-content_fail`
 **Spec:** §8.4
@@ -603,6 +605,32 @@ Paths are under `test/test-cases/verify/…` unless noted. “Verify” means th
 **Expected outcome:** Non-zero exit; temporal validation must fail for all certificates in the chain.
 
 **Impact if it fails:** **Critical security failure** - the time-pinning bug (issue #663) means any expired certificate chain that was internally consistent would be accepted, completely negating certificate expiry as a security control.
+
+#### `certificate-not-yet-valid-intermediate_fail`
+**Spec:** §4.1, §8.2
+
+**What it tests:** That verification rejects a certificate chain where the intermediate CA's validity period has not yet begun (notBefore is in the future).
+
+**Setup:** The root CA is valid, the intermediate CA has notBefore set to one year in the future, and the leaf certificate is issued by that not-yet-valid intermediate. The leaf itself has valid dates.
+
+**Why it exists:** Covers row #5 from sigstore/model-transparency#663. An intermediate CA that is not yet active should not be accepted for chain validation.
+
+**Expected outcome:** Non-zero exit code (verification rejected).
+
+**Impact if it fails:** Clients accept certificate chains with intermediate CAs whose validity period hasn't started, undermining temporal trust guarantees.
+
+#### `certificate-expired-intermediate-expired-leaf_fail`
+**Spec:** §4.1, §8.2
+
+**What it tests:** That verification rejects when both the intermediate CA and the leaf certificate are expired, even though the root CA is still valid.
+
+**Setup:** Valid root CA, but both the intermediate CA (Jan-Jun 2020) and the leaf (Feb-Mar 2020) have expired. This tests cascading expiry detection.
+
+**Why it exists:** Covers row #8 from sigstore/model-transparency#663. Even with a valid root, an expired intermediate + expired leaf chain must be rejected.
+
+**Expected outcome:** Non-zero exit code (verification rejected).
+
+**Impact if it fails:** Clients accept certificate chains where only the root is valid but the entire signing path below it has expired.
 
 #### `key-verify-as-certificate_fail`
 **Spec:** §4.1

--- a/conformance/config/keys.yaml
+++ b/conformance/config/keys.yaml
@@ -264,6 +264,54 @@ keys:
         files: [ca-cert.pem]
         from_group: certificate
 
+  - name: not-yet-valid-intermediate
+    description: Not-yet-valid intermediate CA with valid leaf cert
+    purpose: Test rejection when intermediate CA validity period is in the future
+    when_to_use: "Negative test for intermediate CA temporal validation (issue #663 row 5)"
+    curve: P-384
+    depends_on: certificate
+    files:
+      - name: signing-key.pem
+        description: EC P-384 private key for leaf
+      - name: signing-key-cert.pem
+        description: Valid leaf certificate signed by not-yet-valid intermediate
+      - name: int-ca-cert.pem
+        description: Intermediate CA certificate with not_valid_before in the future
+    roles:
+      - role: sign_private_key
+        file: signing-key.pem
+      - role: sign_cert
+        file: signing-key-cert.pem
+      - role: sign_cert_chain
+        files: [int-ca-cert.pem]
+      - role: verify_cert_chain
+        files: [ca-cert.pem]
+        from_group: certificate
+
+  - name: expired-intermediate-expired-leaf
+    description: Valid root, expired intermediate AND expired leaf
+    purpose: Test rejection when both intermediate and leaf are expired
+    when_to_use: "Negative test for cascading expiry (issue #663 row 8)"
+    curve: P-384
+    depends_on: certificate
+    files:
+      - name: signing-key.pem
+        description: EC P-384 private key for expired leaf
+      - name: signing-key-cert.pem
+        description: Expired leaf certificate
+      - name: int-ca-cert.pem
+        description: Expired intermediate CA certificate
+    roles:
+      - role: sign_private_key
+        file: signing-key.pem
+      - role: sign_cert
+        file: signing-key-cert.pem
+      - role: sign_cert_chain
+        files: [int-ca-cert.pem]
+      - role: verify_cert_chain
+        files: [ca-cert.pem]
+        from_group: certificate
+
   - name: wrong
     description: Unrelated CA and keypair for negative tests
     purpose: Verify that verification fails with non-matching keys

--- a/conformance/config/keys.yaml
+++ b/conformance/config/keys.yaml
@@ -146,6 +146,101 @@ keys:
         files: [ca-cert.pem]
         from_group: certificate
 
+  - name: not-yet-valid
+    description: Leaf cert whose validity period is in the future (notBefore = now + 1 year)
+    purpose: Test that certificates not yet valid are rejected during signing or verification
+    when_to_use: Negative test for certificate temporal validation (future validity)
+    curve: P-384
+    depends_on: certificate
+    files:
+      - name: signing-key.pem
+        description: EC P-384 private key for not-yet-valid cert
+      - name: signing-key-cert.pem
+        description: Leaf certificate with notBefore in the future
+    roles:
+      - role: sign_private_key
+        file: signing-key.pem
+      - role: sign_cert
+        file: signing-key-cert.pem
+      - role: sign_cert_chain
+        files: [int-ca-cert.pem]
+        from_group: certificate
+      - role: verify_cert_chain
+        files: [ca-cert.pem]
+        from_group: certificate
+
+  - name: expired-intermediate
+    description: Expired intermediate CA with valid leaf cert
+    purpose: Test that an expired intermediate CA causes chain verification to fail
+    when_to_use: Negative test for intermediate CA temporal validation
+    curve: P-384
+    depends_on: certificate
+    files:
+      - name: signing-key.pem
+        description: EC P-384 private key for leaf cert
+      - name: signing-key-cert.pem
+        description: Valid leaf certificate issued by expired intermediate CA
+      - name: int-ca-cert.pem
+        description: Expired intermediate CA certificate (notAfter 2020-01-02)
+    roles:
+      - role: sign_private_key
+        file: signing-key.pem
+      - role: sign_cert
+        file: signing-key-cert.pem
+      - role: sign_cert_chain
+        files: [int-ca-cert.pem]
+      - role: verify_cert_chain
+        files: [ca-cert.pem]
+        from_group: certificate
+
+  - name: expired-root
+    description: Expired root CA with valid intermediate and leaf certs
+    purpose: Test that an expired root CA causes chain verification to fail
+    when_to_use: Negative test for root CA temporal validation
+    curve: P-384
+    files:
+      - name: signing-key.pem
+        description: EC P-384 private key for leaf cert
+      - name: signing-key-cert.pem
+        description: Valid leaf certificate
+      - name: int-ca-cert.pem
+        description: Valid intermediate CA certificate
+      - name: ca-cert.pem
+        description: Expired root CA certificate (notAfter 2020-01-02)
+    roles:
+      - role: sign_private_key
+        file: signing-key.pem
+      - role: sign_cert
+        file: signing-key-cert.pem
+      - role: sign_cert_chain
+        files: [int-ca-cert.pem]
+      - role: verify_cert_chain
+        files: [ca-cert.pem]
+
+  - name: all-expired
+    description: Entire chain (root + intermediate + leaf) all expired
+    purpose: Test that verification rejects when all certificates in the chain are expired
+    when_to_use: Negative test for tautological time-pinning bug (issue 663)
+    curve: P-384
+    files:
+      - name: signing-key.pem
+        description: EC P-384 private key for expired leaf cert
+      - name: signing-key-cert.pem
+        description: Expired leaf certificate (notAfter 2020-03-01)
+      - name: int-ca-cert.pem
+        description: Expired intermediate CA certificate (notAfter 2020-06-01)
+      - name: ca-cert.pem
+        description: Expired root CA certificate (notAfter 2020-06-01)
+    roles:
+      - role: sign_private_key
+        file: signing-key.pem
+      - role: sign_cert
+        file: signing-key-cert.pem
+      - role: sign_cert_chain
+        files: [int-ca-cert.pem]
+      - role: verify_cert_chain
+        files: [ca-cert.pem]
+
   - name: no-code-signing
     description: Leaf cert WITHOUT code_signing EKU, signed by certificate chain
     purpose: Test that signing with a cert lacking code_signing EKU is rejected

--- a/conformance/test/assets/generate_keys.py
+++ b/conformance/test/assets/generate_keys.py
@@ -583,6 +583,61 @@ def generate_all_keys(
     _write_cert(ae_dir / "ca-cert.pem", ae_root_cert)
 
     # ------------------------------------------------------------------
+    # not-yet-valid-intermediate/ -- not-yet-valid intermediate CA with valid leaf
+    #                                (row #5 from model-transparency#663)
+    # ------------------------------------------------------------------
+    nyi_dir = keys_dir / "not-yet-valid-intermediate"
+    nyi_curve = _resolve_curve(
+        keys_manifest, "not-yet-valid-intermediate", ec.SECP384R1(),
+    )
+    nyi_int_key, _ = _generate_ec_keypair(nyi_curve)
+    nyi_int_cert = _build_intermediate_ca(
+        ca_key,
+        ca_cert,
+        nyi_int_key,
+        cn="not-yet-valid-intermediate-ca",
+        not_valid_before=now + datetime.timedelta(days=365),
+        not_valid_after=now + datetime.timedelta(days=730),
+    )
+    nyi_leaf_key, nyi_leaf_pub = _generate_ec_keypair(nyi_curve)
+    nyi_leaf_cert = _build_signing_cert(
+        nyi_int_key, nyi_int_cert, nyi_leaf_pub,
+        cn="leaf-of-not-yet-valid-intermediate",
+    )
+    _write_private_key(nyi_dir / "signing-key.pem", nyi_leaf_key)
+    _write_cert(nyi_dir / "signing-key-cert.pem", nyi_leaf_cert)
+    _write_cert(nyi_dir / "int-ca-cert.pem", nyi_int_cert)
+
+    # ------------------------------------------------------------------
+    # expired-intermediate-expired-leaf/ -- valid root, expired intermediate
+    #                                       AND expired leaf (row #8 from
+    #                                       model-transparency#663)
+    # ------------------------------------------------------------------
+    eiel_dir = keys_dir / "expired-intermediate-expired-leaf"
+    eiel_curve = _resolve_curve(
+        keys_manifest, "expired-intermediate-expired-leaf", ec.SECP384R1(),
+    )
+    eiel_int_key, _ = _generate_ec_keypair(eiel_curve)
+    eiel_int_cert = _build_intermediate_ca(
+        ca_key,
+        ca_cert,
+        eiel_int_key,
+        cn="expired-int-for-expired-leaf",
+        not_valid_before=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc),
+        not_valid_after=datetime.datetime(2020, 6, 1, tzinfo=datetime.timezone.utc),
+    )
+    eiel_leaf_key, eiel_leaf_pub = _generate_ec_keypair(eiel_curve)
+    eiel_leaf_cert = _build_signing_cert(
+        eiel_int_key, eiel_int_cert, eiel_leaf_pub,
+        cn="expired-leaf-of-expired-int",
+        not_valid_before=datetime.datetime(2020, 2, 1, tzinfo=datetime.timezone.utc),
+        not_valid_after=datetime.datetime(2020, 3, 1, tzinfo=datetime.timezone.utc),
+    )
+    _write_private_key(eiel_dir / "signing-key.pem", eiel_leaf_key)
+    _write_cert(eiel_dir / "signing-key-cert.pem", eiel_leaf_cert)
+    _write_cert(eiel_dir / "int-ca-cert.pem", eiel_int_cert)
+
+    # ------------------------------------------------------------------
     # Standalone EC keypairs (curves from keys.yaml, defaults below)
     # ------------------------------------------------------------------
     _STANDALONE_DEFAULTS: dict[str, ec.EllipticCurve] = {

--- a/conformance/test/assets/generate_keys.py
+++ b/conformance/test/assets/generate_keys.py
@@ -133,10 +133,14 @@ def _add_aki(
 
 def _build_root_ca(
     key: ec.EllipticCurvePrivateKey,
+    *,
+    cn: str = "root-ca",
+    not_valid_before: datetime.datetime | None = None,
+    not_valid_after: datetime.datetime | None = None,
 ) -> x509.Certificate:
     """Self-signed root CA certificate."""
     subject = issuer = x509.Name([
-        x509.NameAttribute(NameOID.COMMON_NAME, "root-ca"),
+        x509.NameAttribute(NameOID.COMMON_NAME, cn),
     ])
     now = _now()
     pub = key.public_key()
@@ -146,8 +150,8 @@ def _build_root_ca(
         .issuer_name(issuer)
         .public_key(pub)
         .serial_number(x509.random_serial_number())
-        .not_valid_before(now)
-        .not_valid_after(now + _TEN_YEARS)
+        .not_valid_before(not_valid_before or now)
+        .not_valid_after(not_valid_after or (now + _TEN_YEARS))
         .add_extension(
             x509.BasicConstraints(ca=True, path_length=None),
             critical=True,
@@ -175,10 +179,14 @@ def _build_intermediate_ca(
     ca_key: ec.EllipticCurvePrivateKey,
     ca_cert: x509.Certificate,
     int_key: ec.EllipticCurvePrivateKey,
+    *,
+    cn: str = "intermediate-ca",
+    not_valid_before: datetime.datetime | None = None,
+    not_valid_after: datetime.datetime | None = None,
 ) -> x509.Certificate:
     """Intermediate CA certificate signed by root CA."""
     subject = x509.Name([
-        x509.NameAttribute(NameOID.COMMON_NAME, "intermediate-ca"),
+        x509.NameAttribute(NameOID.COMMON_NAME, cn),
     ])
     now = _now()
     pub = int_key.public_key()
@@ -188,8 +196,8 @@ def _build_intermediate_ca(
         .issuer_name(ca_cert.subject)
         .public_key(pub)
         .serial_number(x509.random_serial_number())
-        .not_valid_before(now)
-        .not_valid_after(now + _TEN_YEARS)
+        .not_valid_before(not_valid_before or now)
+        .not_valid_after(not_valid_after or (now + _TEN_YEARS))
         .add_extension(
             x509.BasicConstraints(ca=True, path_length=0),
             critical=True,
@@ -460,6 +468,119 @@ def generate_all_keys(
     )
     _write_private_key(expired_dir / "signing-key.pem", expired_key)
     _write_cert(expired_dir / "signing-key-cert.pem", expired_cert)
+
+    # ------------------------------------------------------------------
+    # not-yet-valid/ -- leaf cert whose validity period is in the future
+    #                   (curve from keys.yaml, default P-384)
+    # ------------------------------------------------------------------
+    nyv_dir = keys_dir / "not-yet-valid"
+    nyv_curve = _resolve_curve(keys_manifest, "not-yet-valid", ec.SECP384R1())
+
+    nyv_key, nyv_pub = _generate_ec_keypair(nyv_curve)
+    now = _now()
+    nyv_cert = _build_signing_cert(
+        int_ca_key,
+        int_ca_cert,
+        nyv_pub,
+        cn="not-yet-valid-signing-key",
+        not_valid_before=now + datetime.timedelta(days=365),
+        not_valid_after=now + datetime.timedelta(days=730),
+        is_ca=False,
+    )
+    _write_private_key(nyv_dir / "signing-key.pem", nyv_key)
+    _write_cert(nyv_dir / "signing-key-cert.pem", nyv_cert)
+
+    # ------------------------------------------------------------------
+    # expired-intermediate/ -- expired intermediate CA with valid leaf
+    #                          (curve from keys.yaml, default P-384)
+    # ------------------------------------------------------------------
+    ei_dir = keys_dir / "expired-intermediate"
+    ei_curve = _resolve_curve(
+        keys_manifest, "expired-intermediate", ec.SECP384R1(),
+    )
+
+    # Reuse the standard root CA (ca_key / ca_cert) from certificate/
+    ei_int_key, _ = _generate_ec_keypair(ei_curve)
+    ei_int_cert = _build_intermediate_ca(
+        ca_key,
+        ca_cert,
+        ei_int_key,
+        cn="expired-intermediate-ca",
+        not_valid_before=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc),
+        not_valid_after=datetime.datetime(2020, 1, 2, tzinfo=datetime.timezone.utc),
+    )
+    ei_leaf_key, ei_leaf_pub = _generate_ec_keypair(ei_curve)
+    ei_leaf_cert = _build_signing_cert(
+        ei_int_key,
+        ei_int_cert,
+        ei_leaf_pub,
+        cn="leaf-of-expired-intermediate",
+    )
+    _write_private_key(ei_dir / "signing-key.pem", ei_leaf_key)
+    _write_cert(ei_dir / "signing-key-cert.pem", ei_leaf_cert)
+    _write_cert(ei_dir / "int-ca-cert.pem", ei_int_cert)
+
+    # ------------------------------------------------------------------
+    # expired-root/ -- expired root CA with valid intermediate and leaf
+    #                  (curve from keys.yaml, default P-384)
+    # ------------------------------------------------------------------
+    er_dir = keys_dir / "expired-root"
+    er_curve = _resolve_curve(keys_manifest, "expired-root", ec.SECP384R1())
+
+    er_root_key, _ = _generate_ec_keypair(er_curve)
+    er_root_cert = _build_root_ca(
+        er_root_key,
+        cn="expired-root-ca",
+        not_valid_before=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc),
+        not_valid_after=datetime.datetime(2020, 1, 2, tzinfo=datetime.timezone.utc),
+    )
+    er_int_key, _ = _generate_ec_keypair(er_curve)
+    er_int_cert = _build_intermediate_ca(
+        er_root_key, er_root_cert, er_int_key,
+        cn="intermediate-of-expired-root",
+    )
+    er_leaf_key, er_leaf_pub = _generate_ec_keypair(er_curve)
+    er_leaf_cert = _build_signing_cert(
+        er_int_key, er_int_cert, er_leaf_pub,
+        cn="leaf-of-expired-root",
+    )
+    _write_private_key(er_dir / "signing-key.pem", er_leaf_key)
+    _write_cert(er_dir / "signing-key-cert.pem", er_leaf_cert)
+    _write_cert(er_dir / "int-ca-cert.pem", er_int_cert)
+    _write_cert(er_dir / "ca-cert.pem", er_root_cert)
+
+    # ------------------------------------------------------------------
+    # all-expired/ -- entire chain (root + intermediate + leaf) expired
+    #                 (curve from keys.yaml, default P-384)
+    # ------------------------------------------------------------------
+    ae_dir = keys_dir / "all-expired"
+    ae_curve = _resolve_curve(keys_manifest, "all-expired", ec.SECP384R1())
+
+    ae_root_key, _ = _generate_ec_keypair(ae_curve)
+    ae_root_cert = _build_root_ca(
+        ae_root_key,
+        cn="all-expired-root-ca",
+        not_valid_before=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc),
+        not_valid_after=datetime.datetime(2020, 6, 1, tzinfo=datetime.timezone.utc),
+    )
+    ae_int_key, _ = _generate_ec_keypair(ae_curve)
+    ae_int_cert = _build_intermediate_ca(
+        ae_root_key, ae_root_cert, ae_int_key,
+        cn="all-expired-intermediate-ca",
+        not_valid_before=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc),
+        not_valid_after=datetime.datetime(2020, 6, 1, tzinfo=datetime.timezone.utc),
+    )
+    ae_leaf_key, ae_leaf_pub = _generate_ec_keypair(ae_curve)
+    ae_leaf_cert = _build_signing_cert(
+        ae_int_key, ae_int_cert, ae_leaf_pub,
+        cn="all-expired-leaf",
+        not_valid_before=datetime.datetime(2020, 2, 1, tzinfo=datetime.timezone.utc),
+        not_valid_after=datetime.datetime(2020, 3, 1, tzinfo=datetime.timezone.utc),
+    )
+    _write_private_key(ae_dir / "signing-key.pem", ae_leaf_key)
+    _write_cert(ae_dir / "signing-key-cert.pem", ae_leaf_cert)
+    _write_cert(ae_dir / "int-ca-cert.pem", ae_int_cert)
+    _write_cert(ae_dir / "ca-cert.pem", ae_root_cert)
 
     # ------------------------------------------------------------------
     # Standalone EC keypairs (curves from keys.yaml, defaults below)

--- a/conformance/test/test-cases/policy-negative.yaml
+++ b/conformance/test/test-cases/policy-negative.yaml
@@ -36,6 +36,52 @@ tests:
   bundle_source:
     type: sign
     key_group: expired
+
+- id: certificate-not-yet-valid_fail
+  description: 'FAIL: Rejection when signing certificate validity period is in the future'
+  spec_refs:
+  - §4.1
+  - §8.2
+  method: certificate
+  model: simple
+  bundle_source:
+    type: sign
+    key_group: not-yet-valid
+
+- id: certificate-expired-intermediate_fail
+  description: 'FAIL: Rejection when intermediate CA certificate in the chain is expired'
+  spec_refs:
+  - §4.1
+  - §8.2
+  method: certificate
+  model: simple
+  bundle_source:
+    type: sign
+    key_group: expired-intermediate
+
+- id: certificate-expired-root_fail
+  description: 'FAIL: Rejection when root CA certificate used as trust anchor is expired'
+  spec_refs:
+  - §4.1
+  - §8.2
+  method: certificate
+  model: simple
+  bundle_source:
+    type: sign
+    key_group: expired-root
+
+- id: certificate-all-expired_fail
+  description: 'FAIL: Rejection when all certificates in the chain (root, intermediate,
+    leaf) are expired'
+  spec_refs:
+  - §4.1
+  - §8.2
+  method: certificate
+  model: simple
+  bundle_source:
+    type: sign
+    key_group: all-expired
+
 - id: certificate-simple-wrong-ca_fail
   description: 'FAIL: Rejection when CA certificate used for verification is not the
     signing CA'

--- a/conformance/test/test-cases/policy-negative.yaml
+++ b/conformance/test/test-cases/policy-negative.yaml
@@ -82,6 +82,30 @@ tests:
     type: sign
     key_group: all-expired
 
+- id: certificate-not-yet-valid-intermediate_fail
+  description: 'FAIL: Rejection when intermediate CA certificate validity period is
+    in the future'
+  spec_refs:
+  - §4.1
+  - §8.2
+  method: certificate
+  model: simple
+  bundle_source:
+    type: sign
+    key_group: not-yet-valid-intermediate
+
+- id: certificate-expired-intermediate-expired-leaf_fail
+  description: 'FAIL: Rejection when both intermediate CA and leaf certificate are
+    expired'
+  spec_refs:
+  - §4.1
+  - §8.2
+  method: certificate
+  model: simple
+  bundle_source:
+    type: sign
+    key_group: expired-intermediate-expired-leaf
+
 - id: certificate-simple-wrong-ca_fail
   description: 'FAIL: Rejection when CA certificate used for verification is not the
     signing CA'


### PR DESCRIPTION
## What

Adds 12 new conformance test cases: 6 certificate validity scenarios covering all temporal validation cases from [sigstore/model-transparency#663](https://github.com/sigstore/model-transparency/issues/663), and 6 new model structures addressing the remaining items from the PR #12 review.

## Why

Issue #663 identified that the Python `model-signing` library accepts expired and not-yet-valid certificates without proper temporal validation. The conformance suite had only 1 test for expired leaf certs — the remaining 7 scenarios (expired intermediate, expired root, not-yet-valid leaf/intermediate, all-expired chain, cascading expiry) were untested.

The model structure gaps (deeply nested paths, multiple .git directories, combined git exclusions) were requested in the PR #12 review but deferred. This PR completes that coverage.

## Summary

**Certificate validity tests (§4.1, §8.2):**

| # | Root | Intermediate | Leaf | Test | Status |
|---|------|-------------|------|------|--------|
| 1 | valid | valid | valid | `certificate-simple` (existing) | Pass |
| 2 | valid | valid | expired | `certificate-expired_fail` (existing) | Pass |
| 3 | valid | valid | not-yet-valid | `certificate-not-yet-valid_fail` | xfail |
| 4 | valid | expired | valid | `certificate-expired-intermediate_fail` | Pass |
| 5 | valid | not-yet-valid | valid | `certificate-not-yet-valid-intermediate_fail` | Pass |
| 6 | expired | valid | valid | `certificate-expired-root_fail` | Pass |
| 7 | expired | expired | expired | `certificate-all-expired_fail` | Pass |
| 8 | valid | expired | expired | `certificate-expired-intermediate-expired-leaf_fail` | Pass |

**Totals:** 92 tests (37 roundtrip + 55 verify), 14 key groups, 19 model fixtures.